### PR TITLE
Production: environment variable for client url to allow CORS

### DIFF
--- a/src/main/java/com/minitwitter/config/ApiConfig.java
+++ b/src/main/java/com/minitwitter/config/ApiConfig.java
@@ -1,0 +1,14 @@
+package com.minitwitter.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Getter
+@Service
+public class ApiConfig {
+
+    @Value("${CLIENT_ENVIRONMENT:http://localhost:4200}")
+    private String clientEnvironment;
+
+}

--- a/src/main/java/com/minitwitter/config/CorsConfiguration.java
+++ b/src/main/java/com/minitwitter/config/CorsConfiguration.java
@@ -1,0 +1,30 @@
+package com.minitwitter.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+@Configuration
+public class CorsConfiguration {
+
+  private final ApiConfig apiConfig;
+
+  @Autowired
+  public CorsConfiguration(ApiConfig apiConfig) {
+    this.apiConfig = apiConfig;
+  }
+
+  @Bean
+  public WebMvcConfigurer corsConfigurer() {
+    return new WebMvcConfigurerAdapter() {
+      @Override
+      public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+          .allowedOrigins(apiConfig.getClientEnvironment());
+      }
+    };
+  }
+}


### PR DESCRIPTION
Added: allowed CORS for values provided as environment variable allowing for having production environment.

https://github.com/edinfazlic/mini-twitter-rest/issues/2