### PR TITLE
Search endpoint

### DIFF
--- a/src/main/java/com/minitwitter/controller/TweetController.java
+++ b/src/main/java/com/minitwitter/controller/TweetController.java
@@ -21,7 +21,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CREATED;
 
 @RestController
-@RequestMapping("tweets")
+@RequestMapping("tweet")
 @Slf4j
 public class TweetController extends ExceptionHandlingController {
 

--- a/src/main/java/com/minitwitter/controller/UserController.java
+++ b/src/main/java/com/minitwitter/controller/UserController.java
@@ -1,14 +1,18 @@
 package com.minitwitter.controller;
 
+import com.minitwitter.domain.dto.FollowInfoUserDTO;
 import com.minitwitter.domain.dto.UserDTO;
 import com.minitwitter.service.UserService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
 import java.util.Collection;
 
 @RestController
+@RequestMapping("user")
 public class UserController {
 
   private UserService userService;
@@ -25,5 +29,10 @@ public class UserController {
   @GetMapping("/following")
   public Collection<UserDTO> following(Principal principal) {
     return userService.getUsersFollowing(principal);
+  }
+
+  @GetMapping()
+  public Collection<FollowInfoUserDTO> search(@RequestParam String searchString, Principal principal) {
+    return userService.searchUsers(searchString, principal);
   }
 }

--- a/src/main/java/com/minitwitter/domain/dto/FollowInfoUserDTO.java
+++ b/src/main/java/com/minitwitter/domain/dto/FollowInfoUserDTO.java
@@ -1,0 +1,18 @@
+package com.minitwitter.domain.dto;
+
+import com.minitwitter.domain.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FollowInfoUserDTO extends UserDTO {
+  boolean follower;
+  boolean following;
+
+  public FollowInfoUserDTO(User user) {
+    super(user);
+  }
+}

--- a/src/main/java/com/minitwitter/domain/dto/TweetDTO.java
+++ b/src/main/java/com/minitwitter/domain/dto/TweetDTO.java
@@ -4,10 +4,8 @@ import com.minitwitter.domain.Tweet;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import static lombok.AccessLevel.PRIVATE;
-
 @Getter
-@NoArgsConstructor(access = PRIVATE)
+@NoArgsConstructor
 public class TweetDTO {
   private Long id;
   private String content;

--- a/src/main/java/com/minitwitter/repository/UserRepository.java
+++ b/src/main/java/com/minitwitter/repository/UserRepository.java
@@ -3,6 +3,19 @@ package com.minitwitter.repository;
 import com.minitwitter.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Collection;
+
 public interface UserRepository extends JpaRepository<User, Long> {
   User findOneByUsername(String user);
+
+  /**
+   * Use instead:
+   * @see UserRepository#findByUsernameFirstNameLastName
+   */
+  Collection<User> findByUsernameContainingIgnoreCaseOrFirstNameContainingIgnoreCaseOrLastNameContainingIgnoreCase(String username, String firstName, String lastName);
+
+  default Collection<User> findByUsernameFirstNameLastName(String searchString) {
+    return findByUsernameContainingIgnoreCaseOrFirstNameContainingIgnoreCaseOrLastNameContainingIgnoreCase(searchString, searchString, searchString);
+  }
+
 }

--- a/src/main/java/com/minitwitter/service/UserService.java
+++ b/src/main/java/com/minitwitter/service/UserService.java
@@ -1,6 +1,7 @@
 package com.minitwitter.service;
 
 import com.minitwitter.domain.User;
+import com.minitwitter.domain.dto.FollowInfoUserDTO;
 import com.minitwitter.domain.dto.UserDTO;
 import com.minitwitter.repository.UserRepository;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -44,6 +45,20 @@ public class UserService implements UserDetailsService {
   public Collection<UserDTO> getUsersFollowers(Principal principal) {
     User user = getUser(principal.getName());
     return convertUsersToDTOs(user.getFollowers());
+  }
+
+  @Transactional
+  public Collection<FollowInfoUserDTO> searchUsers(String searchString, Principal principal) {
+    User user = getUser(principal.getName());
+    Collection<User> allUsersFiltered = userRepository.findByUsernameFirstNameLastName(searchString);
+
+    return allUsersFiltered.stream()
+      .map(filteredUser -> {
+        final FollowInfoUserDTO followInfoUserDTO = new FollowInfoUserDTO(filteredUser);
+        followInfoUserDTO.setFollowing(user.getFollowing().stream().anyMatch(usr -> usr.getId().equals(filteredUser.getId())));
+        followInfoUserDTO.setFollower(user.getFollowers().stream().anyMatch(usr -> usr.getId().equals(filteredUser.getId())));
+        return followInfoUserDTO;
+      }).collect(toList());
   }
 
   private User getUser(String username) {

--- a/src/test/java/com/minitwitter/controller/RestIntegrationTest.java
+++ b/src/test/java/com/minitwitter/controller/RestIntegrationTest.java
@@ -17,6 +17,8 @@ public abstract class RestIntegrationTest {
   private static final int FOLLOWERS_COUNT = 1;
   private static final String[] FOLLOWING_USERS = new String[]{"rogerkver", "satoshiNakamoto", "SatoshiLite", "VitalikButerin"};
   private static final String[] FOLLOWERS = new String[]{"rogerkver"};
+  public static final String SEARCH_STRING = "er";
+  public static final String[] SEARCHED_USERS_FOUND = new String[]{"rogerkver", "VitalikButerin"};
 
   @Autowired
   private TestRestTemplate testRestTemplate;
@@ -47,5 +49,13 @@ public abstract class RestIntegrationTest {
 
   int followersCount() {
     return FOLLOWERS_COUNT;
+  }
+
+  String searchString() {
+    return SEARCH_STRING;
+  }
+
+  String[] searchedUsersFound() {
+    return SEARCHED_USERS_FOUND;
   }
 }

--- a/src/test/java/com/minitwitter/controller/TweetControllerIntegrationTest.java
+++ b/src/test/java/com/minitwitter/controller/TweetControllerIntegrationTest.java
@@ -34,7 +34,7 @@ public class TweetControllerIntegrationTest extends RestIntegrationTest {
   }
 
   private ResponseEntity<TweetDTO> doCreateTweetRequest(String tweetContent) {
-    return withAuthTestRestTemplate().postForEntity("/tweets", tweetContent, TweetDTO.class);
+    return withAuthTestRestTemplate().postForEntity("/tweet", tweetContent, TweetDTO.class);
   }
 
   @Test
@@ -50,7 +50,7 @@ public class TweetControllerIntegrationTest extends RestIntegrationTest {
 
   @Test
   public void tweetsFromFollowing_onlyFollowingAuthorsTweetsAreReturned() {
-    ResponseEntity<TweetDTO[]> response = withAuthTestRestTemplate().getForEntity("/tweets", TweetDTO[].class);
+    ResponseEntity<TweetDTO[]> response = withAuthTestRestTemplate().getForEntity("/tweet", TweetDTO[].class);
     assertThat(response.getStatusCode().is2xxSuccessful(), is(true));
     List<String> authors = extractAuthorNames(response.getBody());
     assertThat(authors, hasSize(followingUsers().length));
@@ -59,7 +59,7 @@ public class TweetControllerIntegrationTest extends RestIntegrationTest {
 
   @Test
   public void tweetsFromUser_onlyThatUserTweetsAreReturned() {
-    ResponseEntity<TweetDTO[]> response = withAuthTestRestTemplate().getForEntity("/tweets/{username}",
+    ResponseEntity<TweetDTO[]> response = withAuthTestRestTemplate().getForEntity("/tweet/{username}",
       TweetDTO[].class, Collections.singletonMap("username", getUsernameOfAuthUser()));
     assertThat(response.getStatusCode().is2xxSuccessful(), is(true));
     List<String> authors = extractAuthorNames(response.getBody());
@@ -69,7 +69,7 @@ public class TweetControllerIntegrationTest extends RestIntegrationTest {
 
   @Test
   public void tweetsFromUserWithWrongUsername_badRequestReturned() {
-    ResponseEntity<ErrorMessage> response = withAuthTestRestTemplate().getForEntity("/tweets/{username}",
+    ResponseEntity<ErrorMessage> response = withAuthTestRestTemplate().getForEntity("/tweet/{username}",
       ErrorMessage.class, Collections.singletonMap("username", "unknown"));
     assertThat(response.getStatusCode(), is(HttpStatus.BAD_REQUEST));
     assertThat(response.getBody().getMessage(), containsString("unknown"));

--- a/src/test/java/com/minitwitter/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/com/minitwitter/controller/UserControllerIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.minitwitter.controller;
 
+import com.minitwitter.domain.dto.FollowInfoUserDTO;
 import com.minitwitter.domain.dto.UserDTO;
 import org.junit.Test;
 import org.springframework.http.ResponseEntity;
@@ -8,16 +9,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class UserControllerIntegrationTest extends RestIntegrationTest {
 
   @Test
   public void followersRequested_allFollowersReturned() {
-    ResponseEntity<UserDTO[]> response = withAuthTestRestTemplate().getForEntity("/followers", UserDTO[].class);
+    ResponseEntity<UserDTO[]> response = withAuthTestRestTemplate().getForEntity("/user/followers", UserDTO[].class);
     assertThat(response.getStatusCode().is2xxSuccessful(), is(true));
     List<UserDTO> followers = Arrays.asList(response.getBody());
     assertThat(followers, hasSize(followers().length));
@@ -26,11 +25,24 @@ public class UserControllerIntegrationTest extends RestIntegrationTest {
 
   @Test
   public void getFollowingFromFirstPage() {
-    ResponseEntity<UserDTO[]> response = withAuthTestRestTemplate().getForEntity("/following", UserDTO[].class);
+    ResponseEntity<UserDTO[]> response = withAuthTestRestTemplate().getForEntity("/user/following", UserDTO[].class);
     assertThat(response.getStatusCode().is2xxSuccessful(), is(true));
     List<UserDTO> following = Arrays.asList(response.getBody());
     assertThat(following, hasSize(followingUsers().length));
     assertThat(extractUsernames(following), containsInAnyOrder(followingUsers()));
+  }
+
+  @Test
+  public void searchRequested_allInfoAboutUsersReturned() {
+    ResponseEntity<FollowInfoUserDTO[]> response = withAuthTestRestTemplate().getForEntity("/user?searchString=" + searchString(), FollowInfoUserDTO[].class);
+    assertThat(response.getStatusCode().is2xxSuccessful(), is(true));
+    List<FollowInfoUserDTO> users = Arrays.asList(response.getBody());
+    assertThat(users, hasSize(searchedUsersFound().length));
+    assertThat(users.stream().map(FollowInfoUserDTO::getUsername).collect(toList()), containsInAnyOrder(searchedUsersFound()));
+    assertThat(users.stream().filter(FollowInfoUserDTO::isFollower).count(), equalTo(1L));
+    assertThat(users.stream().filter(followInfoUserDTO -> !followInfoUserDTO.isFollower()).count(), equalTo(1L));
+    assertThat(users.stream().filter(FollowInfoUserDTO::isFollowing).count(), equalTo(2L));
+    assertThat(users.stream().filter(followInfoUserDTO -> !followInfoUserDTO.isFollowing()).count(), equalTo(0L));
   }
 
 


### PR DESCRIPTION
Added: single search endpoint which takes single search string, and looks for such value in other users username, first name and last name. Used default to shorten the repository method.

https://github.com/edinfazlic/mini-twitter-rest/issues/19